### PR TITLE
[sqitch_pg]: Add inspec tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,66 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.sqitch_pg?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=285&branchName=master)
+
 # sqitch_pg
-This is a Habitat plan for [Sqitch](http://sqitch.org/) with [DBD-Pg](http://search.cpan.org/dist/DBD-Pg/) which is used to do database deploys to PostgreSQL.
+
+database migration framework.  See documentation [here](https://metacpan.org/release/DBD-Pg) and [here](http://sqitch.org)
 
 ## Maintainers
-The Habitat Maintainers humans@habitat.sh
+
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
-This is a hybrid binary + library package, designed to make it easy to install Sqitch for PostgreSQL with a single package definition.
+Library package
 
-## Usage
+### Use as Dependency
 
-Install this package by running:
-```
-hab pkg install -b core/sqitch_pg
+Library packages can be set as runtime or build time dependencies, however they are typically used as buildtime dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/sqitch_pg as a dependency, you can add one of the following to your plan file.
+
+#### Buildtime Dependency
+
+> pkg_build_deps=(core/sqitch_pg)
+
+#### Runtime Dependency
+
+> pkg_deps=(core/sqitch_pg)
+
+### Use as a Library
+
+#### Installation
+
+To install this plan, run the following command:
+
+``hab pkg install core/sqitch_pg``
+
+```bash
+hab pkg install core/sqitch_pg
+» Installing core/sqitch_pg
+☁ Determining latest version of core/sqitch_pg in the 'stable' channel
+→ Found newer installed version (core/sqitch_pg/3.7.4/20200928153746) than remote version (core/sqitch_pg/3.7.4/20200404133705)
+→ Using core/sqitch_pg/3.7.4/20200928153746
+★ Install of core/sqitch_pg/3.7.4/20200928153746 complete with 0 new packages installed.
 ```
 
-Run this package like so:
-```
-cd your_schema_folder
-hab pkg exec core/sqitch_pg sqitch --engine pg deploy "db:pg://${USER}:${PASS}@${HOST}/$DB"
+#### Viewing library files
+
+To view the library files first get the habitat installation directory
+
+```bash
+hab pkg path core/sqitch_pg
+/hab/pkgs/core/sqitch_pg/3.7.4/20200928153746
 ```
 
-For a complete example, see [this db-migrations script](https://github.com/chef/chef-server/blob/master/src/bookshelf/habitat/config/database-migrations.sh)
+Then list the libraries, for example:
+
+```bash
+find $(hab pkg path core/sqitch_pg)/lib -type f
+lib/perl5/x86_64-linux-thread-multi/perllocal.pod
+lib/perl5/x86_64-linux-thread-multi/DBD/Pg.pm
+lib/perl5/x86_64-linux-thread-multi/Bundle/DBD/Pg.pm
+lib/perl5/x86_64-linux-thread-multi/auto/DBD/Pg/.packlist
+lib/perl5/x86_64-linux-thread-multi/auto/DBD/Pg/Pg.so
+lib/perl5/x86_64-linux-thread-multi/.meta/DBD-Pg-3.7.4/install.json
+lib/perl5/x86_64-linux-thread-multi/.meta/DBD-Pg-3.7.4/MYMETA.json
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# sqitch_pg
+This is a Habitat plan for [Sqitch](http://sqitch.org/) with [DBD-Pg](http://search.cpan.org/dist/DBD-Pg/) which is used to do database deploys to PostgreSQL.
+
+## Maintainers
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+This is a hybrid binary + library package, designed to make it easy to install Sqitch for PostgreSQL with a single package definition.
+
+## Usage
+
+Install this package by running:
+```
+hab pkg install -b core/sqitch_pg
+```
+
+Run this package like so:
+```
+cd your_schema_folder
+hab pkg exec core/sqitch_pg sqitch --engine pg deploy "db:pg://${USER}:${PASS}@${HOST}/$DB"
+```
+
+For a complete example, see [this db-migrations script](https://github.com/chef/chef-server/blob/master/src/bookshelf/habitat/config/database-migrations.sh)

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,3 @@
-plan_name: ''
+plan_name: 'sqitch_pg'
+library_filename: 'Pg.pm'
+info_filename: 'perllocal.pod'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines-package-install-next.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,3 +1,4 @@
 ---
 owners:
+  - "@irvingpop"
   - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/sqitch_pg_library_exists.rb
+++ b/controls/sqitch_pg_library_exists.rb
@@ -1,0 +1,37 @@
+title 'Tests to confirm sqitch_pg library exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'sqitch_pg')
+
+control 'core-plans-sqitch_pg-library-exists' do
+  impact 1.0
+  title 'Ensure sqitch_pg library exists'
+  desc '
+  Verify sqitch_pg library by ensuring that 
+  (1) its installation directory exists; 
+  (2) the library exists; 
+  (3) its pkgconfig metadata contains the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  library_filename = input('library_filename', value: 'Pg.pm')
+  library_full_path = File.join(plan_installation_directory.stdout.strip, 'lib', 'perl5', 'x86_64-linux-thread-multi', 'DBD', library_filename)
+  describe file(library_full_path) do
+    it { should exist }
+  end
+
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  info_filename = input('info_filename', value: 'perllocal.pod')
+  pkgconfig_full_path = File.join(plan_installation_directory.stdout.strip, 'lib', 'perl5', 'x86_64-linux-thread-multi', info_filename)
+  describe command("cat #{pkgconfig_full_path}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /VERSION:\s+#{plan_pkg_version}/ }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: sqitch_pg
+title: Habitat Core Plan sqitch_pg
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan sqitch_pg
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,36 @@
+pkg_name=sqitch_pg
+pkg_origin=core
+pkg_version="3.7.4"
+pkg_maintainer="The Habitat Maintainers humans@habitat.sh"
+pkg_license=('Artistic-1.0-Perl' 'GPL-2.0')
+pkg_deps=(
+  core/glibc
+  core/perl
+  core/postgresql-client
+  core/zlib
+  core/sqitch
+)
+pkg_build_deps=(
+  core/cpanminus
+  core/local-lib
+  core/gcc
+  core/make
+)
+pkg_description="Sqitch the database management application, bundled with the DBD::Pg Perl module for PostgreSQL"
+pkg_upstream_url="http://sqitch.org/" # Note: also http://search.cpan.org/dist/DBD-Pg/
+pkg_bin_dirs=(bin)
+
+do_setup_environment() {
+  push_runtime_env PERL5LIB "${pkg_prefix}/lib/perl5/x86_64-linux-thread-multi"
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  source <(perl -I"$(pkg_path_for core/local-lib)/lib/perl5" -Mlocal::lib="$(pkg_path_for core/local-lib)")
+  source <(perl -I"$(pkg_path_for core/cpanminus)/lib/perl5" -Mlocal::lib="$(pkg_path_for core/cpanminus)")
+  source <(perl -Mlocal::lib="$pkg_prefix")
+  cpanm "DBD::Pg@$pkg_version" --local-lib "$pkg_prefix"
+}


### PR DESCRIPTION
Add to chef-base-plans

studio tests:

```rspec
Profile: Habitat Core Plan sqitch_pg (sqitch_pg)
Version: 0.1.0
Target:  local://

  ✔  core-plans-sqitch_pg-library-exists: Ensure sqitch_pg library exists
     ✔  Command: `hab pkg path core/sqitch_pg` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/sqitch_pg` stdout is expected not to be empty
     ✔  File /hab/pkgs/core/sqitch_pg/3.7.4/20200928153746/lib/perl5/x86_64-linux-thread-multi/DBD/Pg.pm is expected to exist
     ✔  Command: `cat /hab/pkgs/core/sqitch_pg/3.7.4/20200928153746/lib/perl5/x86_64-linux-thread-multi/perllocal.pod` exit_status is expected to eq 0
     ✔  Command: `cat /hab/pkgs/core/sqitch_pg/3.7.4/20200928153746/lib/perl5/x86_64-linux-thread-multi/perllocal.pod` stdout is expected not to be empty
     ✔  Command: `cat /hab/pkgs/core/sqitch_pg/3.7.4/20200928153746/lib/perl5/x86_64-linux-thread-multi/perllocal.pod` stdout is expected to match /VERSION:\s+3.7.4/


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 6 successful, 0 failures, 0 skipped
```